### PR TITLE
Optimizations for the response object

### DIFF
--- a/src/SlimDR/Factory.php
+++ b/src/SlimDR/Factory.php
@@ -261,6 +261,10 @@ class Factory
     {
         $deps = $controller->getDependencies($method);
 
+        if(!array_key_exists('params', $args)) {
+            $args['params'] = null;
+        }
+
         $aReturn = array (
             'request' => $request,
             'reponse' => $response,

--- a/src/SlimDR/Factory.php
+++ b/src/SlimDR/Factory.php
@@ -243,7 +243,7 @@ class Factory
                     $request, $response, $args, $contDI, $controller, $method
             );
 
-            call_user_func_array(array($controller, $method), $funcArgs);
+            return call_user_func_array(array($controller, $method), $funcArgs);
         });
     }
 


### PR DESCRIPTION
_**Response Object:**_
As i started my work at a RestApi for a mobileapp with this lib i noticed that the response object wasnt returned in the route. Since the response object is immutable it must be returned in every route.

I changed it. Maybe it is usefull for some other guys.

**_$args['param']:_**
When error_reporting is set to E_NOTICE a message occurs if the slash behind the controller is missing.